### PR TITLE
Support latest versions of dependencies

### DIFF
--- a/DependencyInjection/LooptribeFormSpatialExtension.php
+++ b/DependencyInjection/LooptribeFormSpatialExtension.php
@@ -2,32 +2,32 @@
 
 namespace Looptribe\FormSpatialBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
 class LooptribeFormSpatialExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }
-    
+
     public function prepend(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('twig', array(
-            'form_theme' => array('LooptribeFormSpatialBundle:Form:fields.html.twig')
+            'form_theme' => array('LooptribeFormSpatialBundle:Form:fields.html.twig'),
         ));
     }
 }

--- a/DependencyInjection/LooptribeFormSpatialExtension.php
+++ b/DependencyInjection/LooptribeFormSpatialExtension.php
@@ -27,7 +27,7 @@ class LooptribeFormSpatialExtension extends Extension implements PrependExtensio
     public function prepend(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('twig', array(
-            'form' => array(
+            'form_theme' => array(
                 'resources' => array('LooptribeFormSpatialBundle:Form:fields.html.twig')
             )
         ));

--- a/DependencyInjection/LooptribeFormSpatialExtension.php
+++ b/DependencyInjection/LooptribeFormSpatialExtension.php
@@ -27,9 +27,7 @@ class LooptribeFormSpatialExtension extends Extension implements PrependExtensio
     public function prepend(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('twig', array(
-            'form_theme' => array(
-                'resources' => array('LooptribeFormSpatialBundle:Form:fields.html.twig')
-            )
+            'form_theme' => array('LooptribeFormSpatialBundle:Form:fields.html.twig')
         ));
     }
 }

--- a/Form/DataTransformer/PointTransformer.php
+++ b/Form/DataTransformer/PointTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Looptribe\FormSpatialBundle\Form\DataTransformer;
 
-use CrEOF\Spatial\PHP\Types\Geometry\Point;
+use CrEOF\Spatial\PHP\Types\Geography\Point;
 use Symfony\Component\Form\DataTransformerInterface;
 
 class PointTransformer implements DataTransformerInterface

--- a/Form/DataTransformer/PointTransformer.php
+++ b/Form/DataTransformer/PointTransformer.php
@@ -2,15 +2,16 @@
 
 namespace Looptribe\FormSpatialBundle\Form\DataTransformer;
 
-use Symfony\Component\Form\DataTransformerInterface;
 use CrEOF\Spatial\PHP\Types\Geometry\Point;
+use Symfony\Component\Form\DataTransformerInterface;
 
 class PointTransformer implements DataTransformerInterface
 {
     /**
      * Transforms a Point to a string "lat lng".
      *
-     * @param  Point|null $point
+     * @param Point|null $point
+     *
      * @return string
      */
     public function transform($point)
@@ -25,7 +26,7 @@ class PointTransformer implements DataTransformerInterface
     /**
      * Transforms a string "lat lng" to a Point.
      *
-     * @param  string $number
+     * @param string $number
      *
      * @return Point|null
      */
@@ -36,7 +37,7 @@ class PointTransformer implements DataTransformerInterface
         }
 
         list($lat, $lng) = explode(' ', $string, 2);
-        
+
         return new Point($lng, $lat);
     }
 }

--- a/Form/Type/PointType.php
+++ b/Form/Type/PointType.php
@@ -2,13 +2,12 @@
 
 namespace Looptribe\FormSpatialBundle\Form\Type;
 
+use Looptribe\FormSpatialBundle\Form\DataTransformer\PointTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Looptribe\FormSpatialBundle\Form\DataTransformer\PointTransformer;
 
 class PointType extends AbstractType
 {
-    
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(new PointTransformer());
@@ -23,5 +22,4 @@ class PointType extends AbstractType
     {
         return 'point';
     }
-
 }

--- a/Form/Type/PointType.php
+++ b/Form/Type/PointType.php
@@ -4,18 +4,43 @@ namespace Looptribe\FormSpatialBundle\Form\Type;
 
 use Looptribe\FormSpatialBundle\Form\DataTransformer\PointTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 
 class PointType extends AbstractType
 {
+    /**
+     * @var string Google Maps JS API key
+     */
+    protected $googleMapsApiKey;
+
+    /**
+     * @param string $googleMapsApiKey
+     */
+    public function __construct($googleMapsApiKey)
+    {
+        $this->googleMapsApiKey = $googleMapsApiKey;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(new PointTransformer());
     }
 
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        parent::buildView($view, $form, $options);
+
+        $view->vars = array_replace($view->vars, array(
+            'google_maps_api_key' => $this->googleMapsApiKey,
+        ));
+    }
+
     public function getParent()
     {
-        return 'text';
+        return TextType::class;
     }
 
     public function getName()

--- a/README.md
+++ b/README.md
@@ -28,10 +28,15 @@ public function registerBundles()
 }
 ```
 
+``` yml
+# app/config/parameters.yml
+parameters:
+    looptribe.formspatial.google_maps_api_key: YOUR_API_KEY
+```
+
 ## Usage
 When you create a form set your Point field type as `Looptribe\FormSpatialBundle\Form\Type\PointType`:
 ``` php
-
 <?php
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ public function registerBundles()
 ```
 
 ## Usage
-When you create a form set your Point field type as `'point'`:
+When you create a form set your Point field type as `Looptribe\FormSpatialBundle\Form\Type\PointType`:
 ``` php
 
 <?php
@@ -37,11 +37,11 @@ When you create a form set your Point field type as `'point'`:
     {
         $builder
             // ...
-            ->add('location', 'point')
+            ->add('location', Looptribe\FormSpatialBundle\Form\Type\PointType::class)
             // ...
         ;
     }
 ```
 
 ## Development
-At the moment only the `Point` type is supported.
+At the moment only the geography `Point` type is supported.

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,7 @@ parameters:
 
 services:
     looptribe.formspatial.form.type.point:
-        class: %looptribe.formspatial.form.type.pointclass%
+        class: "%looptribe.formspatial.form.type.pointclass%"
+        arguments: ["%looptribe.formspatial.google_maps_api_key%"]
         tags:
             - { name: form.type, alias: point }

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -2,7 +2,7 @@
     {% spaceless %}
     <input type="hidden" id="{{ id }}" name="{{ full_name }}" value="{{ value }}" />
     <div id="map_{{ id }}" style="height: 400px"></div>
-    <script src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}"></script>
     {% endspaceless %}<script>
         (function() {
             {% if value %}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "symfony/form": "^3.2",
+        "symfony/form": ">=2.8",
         "twig/twig": "^1.12||^2.0",
         "creof/doctrine2-spatial": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,14 @@
             "email": "info@looptribe.com",
             "homepage": "http://www.looptribe.com",
             "role": "Developer"
-        }],
+        }
+    ],
     "require": {
-        "symfony/form": ">=2.2",
-        "twig/twig": ">=1.12",
-        "creof/doctrine2-spatial": "dev-master"
+        "symfony/form": "^3.2",
+        "twig/twig": "^1.12||^2.0",
+        "creof/doctrine2-spatial": "^1.1"
     },
     "autoload": {
-        "psr-0": { "Looptribe\\FormSpatialBundle": "" }
-    },
-    "target-dir": "Looptribe/FormSpatialBundle",
-    "minimum-stability": "dev"
+        "psr-4": { "Looptribe\\FormSpatialBundle\\": "" }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
             "role": "Developer"
         }],
     "require": {
-        "symfony/form": "~2.2",
-        "twig/twig": "~1.12",
+        "symfony/form": ">=2.2",
+        "twig/twig": ">=1.12",
         "creof/doctrine2-spatial": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds support for:

- Symfony forms >=2.8
- Stable version of `creof/doctrine2-spatial`
- Current Google Maps JS API (which now requires an API key)
- Twig >=2.0