### PR TITLE
Use Twig namespace instead of old colon-separated syntax

### DIFF
--- a/DependencyInjection/LooptribeFormSpatialExtension.php
+++ b/DependencyInjection/LooptribeFormSpatialExtension.php
@@ -27,7 +27,7 @@ class LooptribeFormSpatialExtension extends Extension implements PrependExtensio
     public function prepend(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('twig', array(
-            'form_theme' => array('LooptribeFormSpatialBundle:Form:fields.html.twig'),
+            'form_theme' => array('@LooptribeFormSpatial/Form/fields.html.twig'),
         ));
     }
 }


### PR DESCRIPTION
The old-style colon-separated syntax is only supported in Symfony 4 if the `symfony/templating` component is installed. Moreover, overriding templates doesn't work if they're defined using this syntax.

Switching to Twig namespace (automatically created for bundles since SF2.7) fixes both of these issues.